### PR TITLE
Correção de um erro na atribuição do caractere da unidade de temperatura

### DIFF
--- a/Conversor-Unidades-C/src/temperatura.c
+++ b/Conversor-Unidades-C/src/temperatura.c
@@ -44,11 +44,11 @@ void conversorDeTemperatura() {
 
     // Definição da unidade de medida na saída
     if (unidadeFinal == 1)
-        unidadeChar = "C";
+        unidadeChar = 'C';
     if (unidadeFinal == 2);
-        unidadeChar = "F";
+        unidadeChar = 'F';
     if (unidadeFinal == 3)
-        unidadeChar = "K";
+        unidadeChar = 'K';
 
     // Requisição e leitura da temperatura na unidade a ser convertida
     printf("\nDigite o valor da temperatura: ");

--- a/Conversor-Unidades-C/src/temperatura.c
+++ b/Conversor-Unidades-C/src/temperatura.c
@@ -45,7 +45,7 @@ void conversorDeTemperatura() {
     // Definição da unidade de medida na saída
     if (unidadeFinal == 1)
         unidadeChar = 'C';
-    if (unidadeFinal == 2);
+    if (unidadeFinal == 2)
         unidadeChar = 'F';
     if (unidadeFinal == 3)
         unidadeChar = 'K';


### PR DESCRIPTION
Nas linhas 46 a 51, onde é atribuído à variável unidadeChar a letra que representa a unidade de medida de temperatura, havia um erro. Atribuição a uma variável caractere deve ser feita com aspas simples, não duplas. Logo, foi alterado de unidadeChar = "C" para unidadeChar = 'C', por exemplo.

Também havia um ; incorreto na linha 48.