### PR TITLE
Adição conversor de áreas.

### DIFF
--- a/Conversor-Unidades-C/src/area.c
+++ b/Conversor-Unidades-C/src/area.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include "include/area.h"
 
 // Função para converter de metros quadrados para centímetros quadrados
 double metros_para_centimetros(double metros) {
@@ -10,23 +11,18 @@ double centimetros_para_metros(double centimetros) {
     return centimetros / 10000; // 1 cm² = 0,0001 m²
 }
 
-// Função para exibir o menu de conversão de áreas
-void exibir_menu_areas() {
-    printf("=== Conversor de Áreas ===\n");
-    printf("1. Converter de m² para cm²\n");
-    printf("2. Converter de cm² para m²\n");
-    printf("0. Sair\n");
-    printf("==========================\n");
-    printf("Escolha uma opção: ");
-}
-
 // Função que processa as conversões com base na opção escolhida
 void processar_conversao_areas() {
     int opcao;
     double area, resultado;
 
     do {
-        exibir_menu_areas(); // Exibe o menu de conversão
+        printf("=== Conversor de Áreas ===\n");
+        printf("1. Converter de m² para cm²\n");
+        printf("2. Converter de cm² para m²\n");
+        printf("0. Sair\n");
+        printf("==========================\n");
+        printf("Escolha uma opção: ");
         scanf("%d", &opcao); // Lê a opção do usuário
 
         switch (opcao) {

--- a/Conversor-Unidades-C/src/include/area.h
+++ b/Conversor-Unidades-C/src/include/area.h
@@ -1,0 +1,10 @@
+#ifndef CONVERSOR_AREAS_H // Proteção contra inclusão múltipla
+#define CONVERSOR_AREAS_H
+
+// Declaração das funções para conversão de áreas
+
+double metros_para_centimetros(double metros);
+double centimetros_para_metros(double centimetros);
+void processar_conversao_areas();
+
+#endif // CONVERSOR_AREAS_H


### PR DESCRIPTION

Para usar o código, obtenha os arquivos conversor_areas.h (cabeçalho) e conversor_areas.c (implementação) e crie um arquivo main.c contendo #include "conversor_areas.h" e chamando a função processar_conversao_areas() dentro do main(). Compile os arquivos juntos usando um compilador como GCC com o comando gcc main.c conversor_areas.c -o programa_conversoes e execute o programa com ./programa_conversoes. O menu interativo permitirá ao usuário escolher entre converter áreas de metros quadrados para centímetros quadrados, o inverso, ou sair do programa.